### PR TITLE
FacebookSamplePage.page improvement

### DIFF
--- a/src/pages/FacebookSamplePage.page
+++ b/src/pages/FacebookSamplePage.page
@@ -16,14 +16,16 @@
             FacebookSampleController.getFriends('{!accessToken}', function(result, event) {
                 if (event.status) {
                     // result comes back escaped - use Caja to unescape it
-                    var json = html.unescapeEntities(result);
-                    var friends = JSON.parse(json);
+                    //var json = html.unescapeEntities(result);
+                    var friends = JSON.parse(result);
                     // Truncate the array to a maximum of 10 friends
                     friends.data.length = Math.min(10, friends.data.length);
                     $j("#friends").html('<pre>'+JSON.stringify(friends, null, '    ')+'</pre>');
                 } else {
                     alert(event.message + '\n' + JSON.stringify(event));
                 }
+            }, { 
+                escape: false
             });
         }
         


### PR DESCRIPTION
There is no need to unescape json result... you can set it to be unescaped from the beginning.
